### PR TITLE
修正背景圖路徑測試tag.scss、修改index頁面scss測試

### DIFF
--- a/assets/scss/component/_tag.scss
+++ b/assets/scss/component/_tag.scss
@@ -46,7 +46,7 @@
 
 /* 使用：外框 198×52，右側斜邊；左邊貼齊 */
 .tag-btn{
-  @include trapezoid-fixed-left(198px, 52px, 183px, 8px, 0px, #FFF7E9, #E7C795, 10px, 6px);
-  > span{ color:#{$primary-50}; }
+  @include trapezoid-fixed-left(198px, 52px, 183px, 8px, 0px, $primary-50, $primary-400, 10px, 6px);
+  > span{ color: $primary-600; }
   white-space: nowrap;
 }

--- a/assets/scss/pages/_index.scss
+++ b/assets/scss/pages/_index.scss
@@ -26,7 +26,7 @@
   aspect-ratio: 393 / 685;
   position: relative;
   margin: 0 auto;
-  background: url("../assets/images/bg/bg1.png") no-repeat center / cover; //
+  background: url("./assets/images/bg/bg1.png") no-repeat center / cover; //
 }
 
 /* ZZZ 位置： inset（391/262/178/115） */
@@ -57,10 +57,10 @@
     box-shadow: 0 1px 2px rgba(0,0,0,.04); 
 }
 .progress-thin { 
-    height: 6px; --bs-progress-bg: #{$primary-50}; 
+    height: 6px; --bs-progress-bg: $primary-50; 
 }
 .progress-thin .progress-bar { 
-    --bs-progress-bar-bg:  #{$primary-500}; 
+    --bs-progress-bar-bg:  $primary-500; 
 }
 .icon-badge { 
     width:24px; 
@@ -88,11 +88,11 @@
 
 .body {
   height: auto;//暫訂
-  background:#{$primary-50};
+  background: $primary-50;
 }
 
 .icon_cat_can {
-  color: #{$neutral-500};  /* 因為 fill="currentColor" stroke="currentColor" */
+  color: $neutral-500;  /* 因為 fill="currentColor" stroke="currentColor" */
 }
 
 
@@ -106,24 +106,42 @@ $radius-xs: .25rem;
   border-bottom-left-radius: 8px !important; 
   border-bottom-right-radius: 8px !important; }
 
+/* 參數 */
+.accordion.accordion-flush {
+  --acc-item-h: 143px;
+  --acc-peek:   47px;
+}
 /* 讓 flush 也有邊與圓角、項目間留距 */
 .accordion.accordion-flush {
   .accordion-item {
-    background: #{$neutral-0};
+    height: var(--acc-item-h);
+    background: $neutral-0;
     border: 1px solid var(--bs-border-color);
     overflow: hidden;              /* 讓圓角吃到內層 */
+    position: relative;
   }
-  .accordion-item + .accordion-item { margin-top: -1rem; }
+
+   /* 收折時堆疊，只露出 47px（限定「上一張是收折」才套負 margin）*/
+  .accordion-item:not(:has(.accordion-collapse.show)) + .accordion-item {
+    margin-top: calc(-1 * (var(--acc-item-h) - var(--acc-peek))); /* = -96px */
+  }
+
+  /* 標題高度=47px；去掉陰影與箭頭 */
+  .accordion-button{
+    min-height: var(--acc-peek);
+    padding-top: .5rem; padding-bottom: .5rem;
+    box-shadow: none;
+    background-color: transparent !important;
+  }
+  
+  .accordion-button::after{ display:none !important; }
+  .accordion-body{ background-color: transparent !important; }
 
   /* 讓父層底色透出 */
   .accordion-button,
   .accordion-body { background-color: transparent !important; }
-  .accordion-button:focus { box-shadow: none; }
-}
-  /*移除箭頭*/
-   .accordion-button::after { 
-    display: none !important; 
-  }
+  .accordion-button { min-height: var(--acc-peek); padding-top:.5rem; padding-bottom:.5rem; box-shadow:none; }
+
 
 /* 只有最後一張卡片用漸層 */
 .accordion.accordion-flush .accordion-item:last-child {
@@ -145,4 +163,6 @@ $radius-xs: .25rem;
     );
   background-image: var(--bs-gradient);
   overflow: hidden;
+}
+
 }


### PR DESCRIPTION
1.編輯放鬆行程底色錯誤修正
2.測試將index頁面#{$...} 是插值。只有在字串、選擇器、或屬性名稱需要把變數嵌進去時才用。，這種寫法的樣式改回$...
確認樣式是否有正確套用，再修改edit-itinerary頁面
3.測試將index頁面修正和 Mofu 分享我的一天...，卡片標題高度、內容呈現範圍及整個item高度修正